### PR TITLE
Add LangGraph course content agent

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,19 @@
+# Course Content Agent
+
+Este diretório contém um script Python que utiliza [LangGraph](https://github.com/langchain-ai/langgraph) para gerar automaticamente um esboço de curso. O agente faz uma chamada a um modelo da OpenAI para criar módulos e aulas a partir de um tema especificado.
+
+## Requisitos
+
+```bash
+pip install -r requirements.txt
+```
+
+É necessário definir a variável de ambiente `OPENAI_API_KEY` com a sua chave da OpenAI para executar o script.
+
+## Uso
+
+```bash
+python course_content_agent.py "Tema do curso"
+```
+
+O script exibirá a estrutura do curso em formato JSON.

--- a/backend/course_content_agent.py
+++ b/backend/course_content_agent.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import List
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+from langgraph.graph.message import MessageGraph
+
+
+def build_graph() -> MessageGraph:
+    """Builds a simple LangGraph that generates course outlines."""
+    llm = ChatOpenAI(model="gpt-3.5-turbo")
+
+    def generate(messages: List) -> List:
+        return [llm.invoke(messages)]
+
+    builder = MessageGraph()
+    builder.add_node("generator", generate)
+    builder.set_entry_point("generator")
+    builder.set_finish_point("generator")
+    return builder.compile()
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python course_content_agent.py 'Course topic'")
+        raise SystemExit(1)
+    topic = sys.argv[1]
+
+    prompt = (
+        "Crie um curso sobre "
+        f"{topic} com tres modulos e tres aulas em cada modulo.\n"
+        "Responda em JSON no formato: {\n  'modules': [\n"
+        "    {'title': '...', 'lessons': ['...']}, ...]\n}"
+    )
+
+    graph = build_graph()
+    messages = [HumanMessage(content=prompt)]
+    result = graph.invoke(messages)
+    response = result[-1].content
+    try:
+        outline = json.loads(response)
+        print(json.dumps(outline, indent=2, ensure_ascii=False))
+    except json.JSONDecodeError:
+        print(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+langgraph
+langchain-openai


### PR DESCRIPTION
## Summary
- add Python agent using LangGraph to generate course content
- document agent usage and dependencies

## Testing
- `pnpm run check` *(fails: Found 71 errors)*
- `pnpm run typecheck`
- `python -m py_compile backend/course_content_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_6872bb6ce4308326b69924ac2174475c