### PR TITLE
Add flashcards agent

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -18,6 +18,14 @@ python course_content_agent.py "Tema do curso"
 
 O script exibirá a estrutura do curso em formato JSON.
 
+### Gerar flashcards
+
+```bash
+python flashcards_agent.py "Conteúdo do curso"
+```
+
+Isso imprimirá um conjunto de flashcards em JSON.
+
 ## Running
 cd frontend
 ./start-database.sh

--- a/backend/flashcards_agent.py
+++ b/backend/flashcards_agent.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+import sys
+from typing import List
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+from langgraph.graph.message import MessageGraph
+
+
+def build_graph() -> MessageGraph:
+    """Builds a LangGraph that generates flashcards."""
+    llm = ChatOpenAI(model="gpt-4")
+
+    def generate(messages: List) -> List:
+        return [llm.invoke(messages)]
+
+    builder = MessageGraph()
+    builder.add_node("generator", generate)
+    builder.set_entry_point("generator")
+    builder.set_finish_point("generator")
+    return builder.compile()
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        print("Usage: python flashcards_agent.py 'Course content text'")
+        raise SystemExit(1)
+    content = sys.argv[1]
+
+    prompt = (
+        "Crie flashcards com perguntas e respostas curtas baseados no seguinte conte\u00fado:\n"
+        f"{content}\n"
+        "Responda em JSON no formato: {\n  'flashcards': [\n"
+        "    {'question': '...', 'answer': '...'}, ...]\n}"
+    )
+
+    graph = build_graph()
+    messages = [HumanMessage(content=prompt)]
+    result = graph.invoke(messages)
+    response = result[-1].content
+    try:
+        cards = json.loads(response)
+        print(json.dumps(cards, indent=2, ensure_ascii=False))
+    except json.JSONDecodeError:
+        print(response)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,2 +1,3 @@
 langgraph
 langchain-openai
+langflow-base


### PR DESCRIPTION
## Summary
- add `flashcards_agent.py` for generating JSON flashcards
- document how to run the flashcards agent
- add `langflow-base` to backend requirements

## Testing
- `python -m py_compile backend/*.py`
- `pip install -r backend/requirements.txt --dry-run` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6872d8124b9c832691319f9abad1775f