### PR TITLE
Fix circular import in flashcards_agent

### DIFF
--- a/backend/flashcards_agent.py
+++ b/backend/flashcards_agent.py
@@ -8,7 +8,6 @@ from langchain_openai import ChatOpenAI
 from langchain_core.messages import HumanMessage
 from langgraph.graph.message import MessageGraph
 
-from course_content_agent import generate_course_content
 
 
 def build_graph() -> MessageGraph:
@@ -48,6 +47,8 @@ def main() -> None:
         print("Usage: python flashcards_agent.py 'Course topic'")
         raise SystemExit(1)
     topic = sys.argv[1]
+
+    from course_content_agent import generate_course_content
 
     # Generate course content first and then flashcards
     course_content = generate_course_content(topic)


### PR DESCRIPTION
## Summary
- avoid loading `course_content_agent` when importing `flashcards_agent`

## Testing
- `python -m py_compile backend/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6872ee053b408326a47872e8a3e6b625