### PR TITLE
Split course package into separate JSON files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ python course_content_agent.py "Tema do curso"
 ```
 
 This script wraps the `backend/course_content_agent.py` module and works on Windows and Unix systems.
+The generated data will be saved into three files in the current directory:
+
+* `course_content.json` – the structured course outline
+* `flashcards.json` – flashcards for each lesson
+* `quiz.json` – a quiz based on the course content

--- a/backend/README.md
+++ b/backend/README.md
@@ -16,7 +16,11 @@ pip install -r requirements.txt
 python course_content_agent.py "Tema do curso"
 ```
 
-O script exibirá a estrutura do curso em formato JSON.
+O script exibirá a estrutura do curso em formato JSON e também salvará o resultado em três arquivos:
+
+* `course_content.json` – contém o conteúdo do curso
+* `flashcards.json` – flashcards gerados para cada aula
+* `quiz.json` – quiz baseado no curso
 
 ### Gerar flashcards
 

--- a/backend/course_content_agent.py
+++ b/backend/course_content_agent.py
@@ -49,8 +49,14 @@ def generate_course_content(topic: str) -> dict:
         raise
 
 
-def generate_course_package(topic: str, output_file: str = "course_material.json") -> dict:
-    """Generate course content, flashcards and quiz and save them to a file."""
+def generate_course_package(
+    topic: str,
+    course_file: str = "course_content.json",
+    flashcards_file: str = "flashcards.json",
+    quiz_file: str = "quiz.json",
+) -> dict:
+    """Generate course content, flashcards and quiz and save them to files."""
+
     course_content = generate_course_content(topic)
     flashcards = generate_flashcards(course_content)
     content_json = json.dumps(course_content, ensure_ascii=False, indent=2)
@@ -62,8 +68,14 @@ def generate_course_package(topic: str, output_file: str = "course_material.json
         "quiz": quiz,
     }
 
-    with open(output_file, "w", encoding="utf-8") as f:
-        json.dump(package, f, ensure_ascii=False, indent=2)
+    with open(course_file, "w", encoding="utf-8") as f:
+        json.dump(course_content, f, ensure_ascii=False, indent=2)
+
+    with open(flashcards_file, "w", encoding="utf-8") as f:
+        json.dump(flashcards, f, ensure_ascii=False, indent=2)
+
+    with open(quiz_file, "w", encoding="utf-8") as f:
+        json.dump(quiz, f, ensure_ascii=False, indent=2)
 
     return package
 


### PR DESCRIPTION
## Summary
- write each component of the generated course material to its own json file
- document the new files in the READMEs

## Testing
- `python -m py_compile backend/course_content_agent.py`

------
https://chatgpt.com/codex/tasks/task_e_68730f2b3e148326b06979d961b40454